### PR TITLE
Destroy

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -17,6 +17,16 @@ class Api::UsersController < ApiController
     end
   end
 
+  def destroy
+    begin
+      user = User.find(params[:id])
+      user.destroy
+      render json: {}, status: :no_content
+    rescue ActiveRecord::RecordNotFound
+      render json: {}, status: :not_found
+    end
+  end
+
 
   private
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
   namespace :api, defaults: { format: :json } do
-    resources :users, only: [:index, :create] do
+    resources :users, only: [:index, :create, :destroy] do
       resources :goals, only: :create
     end
   end


### PR DESCRIPTION
Again, this grants a tremendous amount of power to anyone with a valid `email:password` combination. Is there a way to limit this method to only delete the user making the request?
